### PR TITLE
Added note about COMBINE_HIDPI_ARTWORK

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -455,6 +455,9 @@ the value of Product Name with the name of your framework.
 
 ![](https://github.com/jverkoey/iOS-Framework/raw/master/gfx/serenityproductname.png)
 
+Finally, because it was created as a Mac OS X target, your bundle's build settings may contain a
+`COMBINE_HIDPI_ARTWORK` setting which you will have to delete or set to `NO`. 
+
 ### Ongoing Step: Add Resources to the Bundle Target Copy Files Phase
 
 Whenever you add new resources that you want to include with your framework you need to add it to


### PR DESCRIPTION
The COMBINE_HIDPI_ARTWORK is now present by default in Mac OS X targets, 
and converts images in normal and @2x variants into a tiff file that
isn't supported by iOS. This setting has to be deleted or set to NO. 
