### PR TITLE
Fix Archive builds of DependentApp

### DIFF
--- a/sample/Serenity/Serenity.xcodeproj/project.pbxproj
+++ b/sample/Serenity/Serenity.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = Serenity;
+				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -331,6 +332,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PRODUCT_NAME = Serenity;
+				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;


### PR DESCRIPTION
These two commits should fix broken Archive builds of the DependentApp as noted in #52 and #72.
- The Public Headers directory has a different location during Archive. 
- Once archives were being built, I had to turn on SKIP_INSTALL for the Resource target as well to avoid building a Generic Archive.
