### PR TITLE
Update build_framework.sh

### DIFF
--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -31,7 +31,7 @@ else
     exit 1
 fi
 
-if [[ "$SF_SDK_PLATFORM" = "iphoneos" ]]
+if [[ "$SF_SDK_PLATFORM" == "iphoneos" ]]
 then
     SF_OTHER_PLATFORM=iphonesimulator
 else


### PR DESCRIPTION
fix the platform check. Otherwise it does not build for simulator along with the iPhone