### PR TITLE
"Add Headers Build Phase" in xcode 6+

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -209,6 +209,10 @@ Click on Add Build Phase > Add Copy Headers.
 **Xcode 5:**
 Add Build Phases from the menu. Click on Editor > Add Build Phase -> Add Copy Headers Build Phase. Note: If the menu options are grayed out, you'll need to click on the whitespace below the Build Phases to regain focus and retry.
 
+**Xcode 6:**
+Add Build Phases from the menu. Click on Editor > Add Build Phase -> Add Headers Build Phase. Note: If the menu options are grayed out, you'll need to click on the whitespace below the Build Phases to regain focus and retry.
+
+
 You'll see 3 sections for Public, Private, and Project headers. To modify the scope of any header, drag and drop the header files between the sections. Alternatively you can open the Project Navigator and select the header. Next expand the Utilities pane for the File Inspector.
 ![](https://github.com/jverkoey/iOS-Framework/raw/master/gfx/utilitiesbutton.png)
 (Cmd+Option+0).


### PR DESCRIPTION
"Add Copy Headers Build Phase" has been renamed to " Add Headers Build Phase" in xcode 6+.
